### PR TITLE
Downgrade install-latest.sh to 1.18.0

### DIFF
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAG=${SESAM_TAG:-1.18.1}
+TAG=${SESAM_TAG:-1.18.0}
 
 wget -O sesam.tar.gz https://github.com/sesam-community/sesam-py/releases/download/$TAG/sesam-linux-$TAG.tar.gz
 tar -xf sesam.tar.gz


### PR DESCRIPTION
The newest release is missing the build files:
sesam-linux-1.18.0.tar.gz
sesam-osx-1.18.0.tar.gz
sesam-windows-1.18.0.zip

Therefore downgrade so the download URL inside this "install-latest.sh" file works.