### PR TITLE
remove post-testdata command. does not exist anymore

### DIFF
--- a/tests/embedded_conversion_test/run_test.sh
+++ b/tests/embedded_conversion_test/run_test.sh
@@ -16,7 +16,7 @@ $SESAM_CLIENT -node $NODE_URL -jwt $PUBLIC_CI_TOKEN -skip-tls-verification -v wi
 $SESAM_CLIENT -node $NODE_URL -jwt $PUBLIC_CI_TOKEN -v convert
 
 # Then, test if it works to upload (along with testdata), run, and verify
-$SESAM_CLIENT -node $NODE_URL -jwt $PUBLIC_CI_TOKEN -skip-tls-verification -v -use-internal-scheduler -print-scheduler-log -post-testdata test
+$SESAM_CLIENT -node $NODE_URL -jwt $PUBLIC_CI_TOKEN -skip-tls-verification -v -use-internal-scheduler -print-scheduler-log test
 
 popd
 


### PR DESCRIPTION
 - Since the input pipes are converted to http_endpoints, the datasets will not be cleaned on test run. This means that if you remove entities in the test data, it will not be reflected in sesam, since http_endpoint dont delete datasets.

- Reformatting the repo testdata to reflect how sesam works.

- Pipes needs to be enabled before it can receive data on http_endpoint.

-  Camelcased _id's in pipes does not convert embedded testdata since the files in testdata vs pipenames do not match. Fixed by using the _id as name for testdata file.

