### PR TITLE
Correct releases link

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ When doing `sesam upload` or `sesam test`, the CLI will also upload testdata to 
 ## Installing
 
 You can either run the sesam.py script directly using python, or you can download and run a stand alone 
-binary from [Github Releases](https://github.com/tombech/sesam-py/releases/).
+binary from [Github Releases](https://github.com/sesam-community/sesam-py/releases/).
 
 
 To install and run the sesam client with python on Linux/OSX (python 3.5+ required):


### PR DESCRIPTION
Releases link still points to tom's repo. Should be adjusted so people don't download old versions.