### PR TITLE
Changed $NODE_URL

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -16,11 +16,14 @@ if [ -z "$TRAVIS_OS_NAME" ] ; then
     export SESAM_CLIENT=~/bin/sesam-py
 fi
 
+if [ -z "$NODE_URL" ]; then
+    export $NODE_URL=https://datahub-29ecbb31.sesam.cloud/api
+fi
+
 $SESAM_CLIENT -h
 
 # Only run the tests on linux for now
 if [ "$TRAVIS_OS_NAME" == "linux"   ] ; then
-    export NODE_URL=https://datahub-cd9f97d6.sesam.cloud/api
     export PUBLIC_CI_TOKEN=$SESAM_TOKEN
 
     pushd tests

--- a/test.sh
+++ b/test.sh
@@ -17,7 +17,7 @@ if [ -z "$TRAVIS_OS_NAME" ] ; then
 fi
 
 if [ -z "$NODE_URL" ]; then
-    export $NODE_URL=https://datahub-29ecbb31.sesam.cloud/api
+    export NODE_URL=https://datahub-29ecbb31.sesam.cloud/api
 fi
 
 $SESAM_CLIENT -h


### PR DESCRIPTION
We moved the CI test subscription to the prod portal with the new url https://datahub-29ecbb31.sesam.cloud/api. This PR also allows setting the $NODE_URL env var in Travis settings to override it.