### PR TITLE
IS-10767: Fixes for testdata upload

### DIFF
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAG=${SESAM_TAG:-2.2.0}
+TAG=${SESAM_TAG:-2.2.1}
 
 wget -O sesam.tar.gz https://github.com/sesam-community/sesam-py/releases/download/$TAG/sesam-linux-$TAG.tar.gz
 tar -xf sesam.tar.gz

--- a/sesam.py
+++ b/sesam.py
@@ -1,4 +1,5 @@
 import requests
+from requests.exceptions import HTTPError
 import argparse
 import logging
 import threading
@@ -772,7 +773,11 @@ class SesamCmdClient:
                         if entities_json is not None:
                             # deleting dataset before pushing data, since http_endpoint receiver will not delete
                             # existing test data.
-                            self.sesam_node.delete_dataset(pipe_id)
+                            try:
+                                resp = self.sesam_node.delete_dataset(pipe_id)
+                            except HTTPError as http_e:
+                                self.logger.log(LOGLEVEL_TRACE, f"Failed to delete dataset {pipe_id}. It probably doesn't exist, "
+                                                  f"which is fine. Error: {http_e}")
                             self.sesam_node.enable_pipe(pipe_id)
                             self.sesam_node.pipe_receiver_post_request(pipe_id, json=entities_json)
                             self.sesam_node.disable_pipe(pipe_id)

--- a/sesam.py
+++ b/sesam.py
@@ -1365,7 +1365,7 @@ class SesamCmdClient:
     def run_internal_scheduler(self):
         start_time = time.monotonic()
 
-        disable_pipes = self.args.enable_user_pipes
+        disable_pipes = not self.args.enable_user_pipes
         zero_runs = self.args.scheduler_zero_runs
         max_runs = self.args.scheduler_max_runs
         max_run_time = self.args.scheduler_max_run_time

--- a/sesam.py
+++ b/sesam.py
@@ -315,12 +315,10 @@ class SesamNode:
     def get_internal_pipes(self):
         return [p for p in self.api_connection.get_pipes() if self.get_pipe_type(p) == "internal"]
 
-    def run_internal_scheduler(self, disable_pipes=True, zero_runs=None, max_run_time=None, max_runs=None, delete_input_datasets=True):
+    def run_internal_scheduler(self, zero_runs=None, max_run_time=None, max_runs=None, delete_input_datasets=True):
         internal_scheduler_url = "%s/pipes/run-all-pipes" % self.node_url
 
         params = {}
-        if disable_pipes:
-            params["disable_pipes"] = "true"
 
         if zero_runs is not None:
             params["extra_zero_runs"] = zero_runs
@@ -1365,7 +1363,6 @@ class SesamCmdClient:
     def run_internal_scheduler(self):
         start_time = time.monotonic()
 
-        disable_pipes = not self.args.enable_user_pipes
         zero_runs = self.args.scheduler_zero_runs
         max_runs = self.args.scheduler_max_runs
         max_run_time = self.args.scheduler_max_run_time
@@ -1380,8 +1377,7 @@ class SesamCmdClient:
 
             def run(self):
                 try:
-                    self.result = self.sesam_node.run_internal_scheduler(disable_pipes=disable_pipes,
-                                                                         max_run_time=max_run_time,
+                    self.result = self.sesam_node.run_internal_scheduler(max_run_time=max_run_time,
                                                                          max_runs=max_runs,
                                                                          zero_runs=zero_runs,
                                                                          delete_input_datasets=delete_input_datasets)

--- a/sesam.py
+++ b/sesam.py
@@ -26,7 +26,7 @@ from decimal import Decimal
 import pprint
 from jsonformat import format_object, FormatStyle
 
-sesam_version = "2.2.0"
+sesam_version = "2.2.1"
 
 logger = logging.getLogger('sesam')
 LOGLEVEL_TRACE = 2

--- a/sesam.py
+++ b/sesam.py
@@ -315,7 +315,7 @@ class SesamNode:
     def get_internal_pipes(self):
         return [p for p in self.api_connection.get_pipes() if self.get_pipe_type(p) == "internal"]
 
-    def run_internal_scheduler(self, disable_pipes=True, zero_runs=None, max_run_time=None, max_runs=None):
+    def run_internal_scheduler(self, disable_pipes=True, zero_runs=None, max_run_time=None, max_runs=None, delete_input_datasets=True):
         internal_scheduler_url = "%s/pipes/run-all-pipes" % self.node_url
 
         params = {}
@@ -330,6 +330,10 @@ class SesamNode:
 
         if max_runs is not None:
             params["max_runs"] = max_runs
+
+        if not delete_input_datasets:
+            # Default is True
+            params["delete_input_datasets"] = False
 
         resp = self.api_connection.session.post(internal_scheduler_url, params=params)
         resp.raise_for_status()
@@ -1365,6 +1369,7 @@ class SesamCmdClient:
         zero_runs = self.args.scheduler_zero_runs
         max_runs = self.args.scheduler_max_runs
         max_run_time = self.args.scheduler_max_run_time
+        delete_input_datasets = not os.path.isdir("testdata")
 
         class SchedulerRunner(threading.Thread):
             def __init__(self, sesam_node):
@@ -1378,7 +1383,8 @@ class SesamCmdClient:
                     self.result = self.sesam_node.run_internal_scheduler(disable_pipes=disable_pipes,
                                                                          max_run_time=max_run_time,
                                                                          max_runs=max_runs,
-                                                                         zero_runs=zero_runs)
+                                                                         zero_runs=zero_runs,
+                                                                         delete_input_datasets=delete_input_datasets)
                     if self.result["status"] == "success":
                         self.status = "finished"
                     else:


### PR DESCRIPTION
- the client now won't crash if it tries to delete datasets that don't exist when uploading test data
- using the delete_input_datasets parameter when running the internal scheduler
- disabling user pipes by default (fix logic flip)