### PR TITLE
IS-14105 bugfix: connectorpy module not found again

### DIFF
--- a/connector_cli/connectorpy.py
+++ b/connector_cli/connectorpy.py
@@ -38,7 +38,7 @@ def expand_connector_config(connector_dir, system_placeholder):
             block_end_string="%}}",
         )
 
-    main_env = jinja_env(loader=PackageLoader("connectorpy"))
+    main_env = jinja_env(loader=PackageLoader("connector_cli.connectorpy"))
 
     shim_template = main_env.get_template("shim.json")
 

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAG=${SESAM_TAG:-2.5.10}
+TAG=${SESAM_TAG:-2.5.11}
 
 wget -O sesam.tar.gz https://github.com/sesam-community/sesam-py/releases/download/$TAG/sesam-linux-$TAG.tar.gz
 tar -xf sesam.tar.gz

--- a/readme.install.md
+++ b/readme.install.md
@@ -12,7 +12,7 @@ $ virtualenv --python=python3 venv
 $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ python sesam.py -version
-sesam version 2.5.10
+sesam version 2.5.11
 ```
 
 
@@ -24,7 +24,7 @@ $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ pyinstaller --onefile sesam.py
 $ dist/sesam -version
-sesam version 2.5.10
+sesam version 2.5.11
 ```
 
 ### [Back to main page](./README.md)

--- a/sesam.py
+++ b/sesam.py
@@ -30,7 +30,7 @@ from connector_cli.connectorpy import *
 from connector_cli.oauth2login import *
 from connector_cli.tripletexlogin import *
 
-sesam_version = "2.5.10"
+sesam_version = "2.5.11"
 
 logger = logging.getLogger('sesam')
 LOGLEVEL_TRACE = 2


### PR DESCRIPTION
This small PR fixes the old binary bug "connectorpy module not found", after merging the latest bugfix from connector cli. Since connector cli is in a separate directory in sesampy, the module address should be corrected.