### PR TITLE
IS-14127 Download configs into .expanded directory

### DIFF
--- a/sesam.py
+++ b/sesam.py
@@ -1091,9 +1091,10 @@ class SesamCmdClient:
 
     def download(self):
         if self.args.is_connector:
-            os.chdir(os.path.join(self.args.connector_dir))
             if not os.path.isdir(self.args.expanded_dir):
-                logger.warning("Expanded directory '%s' does not exist. Continuing without collapse." % self.args.expanded_dir)
+                logger.warning("Expanded directory '%s' does not exist. creating the directory." % self.args.expanded_dir)
+                os.makedirs(os.path.join(self.args.connector_dir, self.args.expanded_dir))
+            os.chdir(os.path.join(self.args.connector_dir, self.args.expanded_dir))
 
         # Find env vars to download
         profile_file = "%s-env.json" % self.args.profile
@@ -1153,8 +1154,10 @@ class SesamCmdClient:
 
 
         if self.args.is_connector:
-            if os.path.isdir(self.args.expanded_dir):
+            if os.getcwd().endswith(self.args.expanded_dir):
+                os.chdir("..")
                 collapse_connector(".", self.args.system_placeholder, self.args.expanded_dir)
+
 
     def status(self):
         def log_and_get_diff_flag(file_content1, file_content2, file_name1, file_name2, log_diff=True):

--- a/sesam.py
+++ b/sesam.py
@@ -932,6 +932,7 @@ class SesamCmdClient:
 
 
     def authenticate(self):
+        os.chdir(self.args.connector_dir)
         self.args.service_url=self.node_url
         self.args.service_jwt=self.jwt_token
         if os.path.isfile("manifest.json"): # If manifest.json is in working directory


### PR DESCRIPTION
This PR makes the "sesam download" command to download configs into .expanded directory.
In the edge case of .expanded directory does not exist, it will create the directory and download the configs.
* a bug is also fixed with "sesam authenticate" when running the command from root.