### PR TITLE
IS-14325 Add "sesam validate" command + bugfix

### DIFF
--- a/connector_cli/connectorpy.py
+++ b/connector_cli/connectorpy.py
@@ -46,7 +46,7 @@ node_metadata = {
 }
 
 
-def expand_connector_config(connector_dir, system_placeholder):
+def expand_connector_config(system_placeholder):
     output = []
 
     def jinja_env(loader):
@@ -63,8 +63,8 @@ def expand_connector_config(connector_dir, system_placeholder):
 
     shim_template = main_env.get_template("shim.json")
 
-    with open(os.path.join(connector_dir, "manifest.json"), "r") as f:
-        system_env = jinja_env(loader=FileSystemLoader(connector_dir))
+    with open(os.path.join("manifest.json"), "r") as f:
+        system_env = jinja_env(loader=FileSystemLoader("."))
 
         manifest = json.load(f)
 
@@ -98,10 +98,10 @@ def expand_connector_config(connector_dir, system_placeholder):
     return output, manifest
 
 
-def expand_connector(connector_dir=".", system_placeholder="xxxxxx", expanded_dir=".expanded", profile="test"):
+def expand_connector(system_placeholder="xxxxxx", expanded_dir=".expanded", profile="test"):
     # put the expanded configuration into a subfolder in the connector directory in a form that can be used by sesam-py
-    output, manifest = expand_connector_config(connector_dir, system_placeholder)
-    dirpath = Path(connector_dir, expanded_dir)
+    output, manifest = expand_connector_config(system_placeholder)
+    dirpath = Path(expanded_dir)
     if dirpath.exists() and dirpath.is_dir():
         shutil.rmtree(dirpath)
     os.makedirs(dirpath)
@@ -111,8 +111,8 @@ def expand_connector(connector_dir=".", system_placeholder="xxxxxx", expanded_di
         json.dump(node_metadata, f, indent=2, sort_keys=True)
     profile_file = "%s-env.json" % profile
     # get the existing profile file if it exists
-    if os.path.exists(os.path.join(connector_dir, profile_file)):
-        with open(os.path.join(connector_dir, profile_file), "r", encoding="utf-8-sig") as f:
+    if os.path.exists(profile_file):
+        with open(profile_file, "r", encoding="utf-8-sig") as f:
             new_manifest = json.load(f)
     else:
         new_manifest = {**{"node-env": "test"},

--- a/connector_cli/oauth2login.py
+++ b/connector_cli/oauth2login.py
@@ -80,6 +80,8 @@ def login_callback():
     env = {}
     try:
         env = sesam_node.get_env()
+        if manifest.get("requires_service_api_access"):
+            env["service_url"] = service_url
         if os.path.isfile(profile_file):
             with open(profile_file, "r", encoding="utf-8-sig") as f:
                 for key, value in json.load(f).items():

--- a/connector_cli/oauth2login.py
+++ b/connector_cli/oauth2login.py
@@ -80,8 +80,8 @@ def login_callback():
     env = {}
     try:
         env = sesam_node.get_env()
-        if os.path.isfile(os.path.join(connector_dir, profile_file)):
-            with open(os.path.join(connector_dir, profile_file), "r", encoding="utf-8-sig") as f:
+        if os.path.isfile(profile_file):
+            with open(profile_file, "r", encoding="utf-8-sig") as f:
                 for key, value in json.load(f).items():
                     env[key] = value
         env["token_url"] = token_url
@@ -105,8 +105,7 @@ def login_callback():
 
 
 def start_server(args):
-    global system_id, client_id, client_secret, login_url, token_url, event, profile_file, connector_dir,manifest,service_url,service_jwt
-    connector_dir = args.connector_dir
+    global system_id, client_id, client_secret, login_url, token_url, event, profile_file,manifest,service_url,service_jwt
     profile_file = "%s-env.json" % args.profile
     system_id = args.system_placeholder
     client_id = args.client_id
@@ -116,7 +115,7 @@ def start_server(args):
     login_url = args.login_url
     token_url = args.token_url
     scopes = args.scopes
-    _, manifest = expand_connector_config(connector_dir, system_id)
+    _, manifest = expand_connector_config(system_id)
     if system_id and client_id and client_secret and service_url and login_url and token_url and scopes:
         params = {
             "client_id": client_id,

--- a/connector_cli/tripletexlogin.py
+++ b/connector_cli/tripletexlogin.py
@@ -14,8 +14,7 @@ def login_via_tripletex(sesam_node, args):
     employee_token = args.employee_token
     base_url = args.base_url
     profile = args.profile
-    connector_dir = args.connector_dir
-    _, manifest = expand_connector_config(connector_dir, system_id)
+    _, manifest = expand_connector_config(system_id)
 
     expiration = (date.today() + timedelta(days=args.days)).strftime("%Y-%m-%d")
     if system_id and consumer_token and employee_token and base_url:
@@ -56,8 +55,8 @@ def login_via_tripletex(sesam_node, args):
         try:
             profile_file = "%s-env.json" % profile
             env = sesam_node.get_env()
-            if os.path.isfile(os.path.join(connector_dir, profile_file)):
-                with open(os.path.join(connector_dir, profile_file), "r", encoding="utf-8-sig") as f:
+            if os.path.isfile(profile_file):
+                with open(profile_file, "r", encoding="utf-8-sig") as f:
                     for key, value in json.load(f).items():
                         env[key] = value
             env["base_url"] = base_url

--- a/connector_cli/tripletexlogin.py
+++ b/connector_cli/tripletexlogin.py
@@ -55,6 +55,8 @@ def login_via_tripletex(sesam_node, args):
         try:
             profile_file = "%s-env.json" % profile
             env = sesam_node.get_env()
+            if manifest.get("requires_service_api_access"):
+                env["service_url"] = args.service_url
             if os.path.isfile(profile_file):
                 with open(profile_file, "r", encoding="utf-8-sig") as f:
                     for key, value in json.load(f).items():

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAG=${SESAM_TAG:-2.5.21}
+TAG=${SESAM_TAG:-2.5.22}
 
 wget -O sesam.tar.gz https://github.com/sesam-community/sesam-py/releases/download/$TAG/sesam-linux-$TAG.tar.gz
 tar -xf sesam.tar.gz

--- a/readme.install.md
+++ b/readme.install.md
@@ -12,7 +12,7 @@ $ virtualenv --python=python3 venv
 $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ python sesam.py -version
-sesam version 2.5.21
+sesam version 2.5.22
 ```
 
 
@@ -24,7 +24,7 @@ $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ pyinstaller --onefile sesam.py
 $ dist/sesam -version
-sesam version 2.5.21
+sesam version 2.5.22
 ```
 
 ### [Back to main page](./README.md)

--- a/readme.usage.md
+++ b/readme.usage.md
@@ -221,6 +221,10 @@ Verifying output (2/3)...passed!
 Run completed.
 Verifying output (3/3)...passed!
 ```
+* "upload" command is tied together with validate (before upload) and authenticate (after upload), 
+so if you have a local config that does not pass the validation criteria, it will not be uploaded.
+Above that, "upload" will set the necessary environment variables and secrets through the authentication process.
+For the case of using webhook pipes, "upload" command sets the correct permissions for the pipe as well.
 
 ## Configuring tests
 
@@ -396,5 +400,7 @@ systems/email-system.conf.json
 Please note the path separator, it should always be given as a forward slash - even if you're running on Windows.
 
 Example: `sesam -whitelist-file whitelist.txt test`
+
+
 
 ### [Back to main page](./README.md)

--- a/readme.usage.md
+++ b/readme.usage.md
@@ -87,6 +87,7 @@ Commands:
   authenticate   Authenticates against the external service of the connector and updates secrets and environment variables (available only when working on a connector)
   wipe      Deletes all the pipes, systems, user datasets and environment variables in the node
   restart   Restarts the target node (typically used to release used resources if the environment is strained)
+  validate  Validate local config for proper formatting and internal consistency (will be run automatically before upload. can also be run independently)
   upload    Replace node config with local config. Also tries to upload testdata if 'testdata' folder present and updates secrets and environment variables when working on a connector (might ask for authentication).
   download  Replace local config with node config
   dump      Create a zip archive of the config and store it as 'sesam-config.zip'

--- a/sesam.py
+++ b/sesam.py
@@ -989,27 +989,21 @@ class SesamCmdClient:
                             logger.error("Config file '%s' is not valid json" % file)
                             is_valid=False
 
-                        if "collect" in file:
-                            if type(config.get("transform"))==dict:
-                                if config.get("transform").get("template") == "transform-collect-rest":
+                        if "collect" in file and type(config.get("transform"))==list:
+                            for transform in config.get("transform"):
+                                if transform.get("template") == "transform-collect-rest":
                                     if not "exclude_completeness" in config.keys():
                                         logger.error("Config file '%s' is missing 'exclude_completeness' property" % file)
                                         is_valid=False
-                            elif type(config.get("transform"))==list:
-                                for transform in config.get("transform"):
-                                    if transform.get("template") == "transform-collect-rest":
-                                        if not "exclude_completeness" in config.keys():
-                                            logger.error("Config file '%s' is missing 'exclude_completeness' property" % file)
-                                            is_valid=False
-                                        elif not transform.get("properties"):
-                                            logger.error("Config file '%s' is missing 'properties' property" % file)
-                                            is_valid=False
-                                        elif not transform.get("properties").get("share_dataset"):
-                                            logger.error("Config file '%s' is missing 'share_dataset' property in 'properties'" % file)
-                                            is_valid=False
-                                        elif not transform.get("properties").get("share_dataset") in config.get("exclude_completeness"):
-                                            logger.error("Config file '%s' is missing '%s' in 'exclude_completeness'" % (file, transform.get("properties").get("share_dataset")))
-                                            is_valid=False
+                                    elif not transform.get("properties"):
+                                        logger.error("Config file '%s' is missing 'properties' property" % file)
+                                        is_valid=False
+                                    elif not transform.get("properties").get("share_dataset"):
+                                        logger.error("Config file '%s' is missing 'share_dataset' property in 'properties'" % file)
+                                        is_valid=False
+                                    elif not transform.get("properties").get("share_dataset") in config.get("exclude_completeness"):
+                                        logger.error("Config file '%s' is missing '%s' in 'exclude_completeness'" % (file, transform.get("properties").get("share_dataset")))
+                                        is_valid=False
 
                         if "share" in file:
                             # validate "batch_size": 1 exists on the pipes that has "template": "transform-share-rest"

--- a/sesam.py
+++ b/sesam.py
@@ -30,7 +30,7 @@ from connector_cli.connectorpy import *
 from connector_cli.oauth2login import *
 from connector_cli.tripletexlogin import *
 
-sesam_version = "2.5.21"
+sesam_version = "2.5.22"
 
 logger = logging.getLogger('sesam')
 LOGLEVEL_TRACE = 2

--- a/sesam.py
+++ b/sesam.py
@@ -987,7 +987,16 @@ class SesamCmdClient:
                         except BaseException as e:
                             logger.error("Config file '%s' is not valid json" % file)
 
-
+                        if "collect" in file:
+                            if type(config.get("transform"))==dict:
+                                if config.get("transform").get("template") == "transform-collect-rest":
+                                    if not "exclude_completeness" in config.keys():
+                                        logger.error("Config file '%s' is missing 'exclude_completeness' property" % file)
+                            elif type(config.get("transform"))==list:
+                                for transform in config.get("transform"):
+                                    if transform.get("template") == "transform-collect-rest":
+                                        if not "exclude_completeness" in config.keys():
+                                            logger.error("Config file '%s' is missing 'exclude_completeness' property" % file)
             logger.warning("All json files are valid")
 
     def upload(self):

--- a/sesam.py
+++ b/sesam.py
@@ -1001,6 +1001,15 @@ class SesamCmdClient:
                                         if not "exclude_completeness" in config.keys():
                                             logger.error("Config file '%s' is missing 'exclude_completeness' property" % file)
                                             is_valid=False
+                                        elif not transform.get("properties"):
+                                            logger.error("Config file '%s' is missing 'properties' property" % file)
+                                            is_valid=False
+                                        elif not transform.get("properties").get("share_dataset"):
+                                            logger.error("Config file '%s' is missing 'share_dataset' property in 'properties'" % file)
+                                            is_valid=False
+                                        elif not transform.get("properties").get("share_dataset") in config.get("exclude_completeness"):
+                                            logger.error("Config file '%s' is missing '%s' in 'exclude_completeness'" % (file, transform.get("properties").get("share_dataset")))
+                                            is_valid=False
 
                         if "share" in file:
                             # validate "batch_size": 1 exists on the pipes that has "template": "transform-share-rest"
@@ -1019,6 +1028,8 @@ class SesamCmdClient:
                 logger.warning("All config files are valid")
             else:
                 logger.error("One or more config files are not valid. Check the log for more information")
+        else:
+            logger.error("Failed to validate. Config files are not expanded.")
 
     def upload(self):
         # Find env vars to upload

--- a/sesam.py
+++ b/sesam.py
@@ -2224,6 +2224,7 @@ Commands:
   restart   Restarts the target node (typically used to release used resources if the environment is strained)
   reset     Deletes the entire node database and restarts the node (this is a more thorough version than "wipe" - requires the target node to be a designated developer node, contact support@sesam.io for help)
   init      Add conditional sources with testing and production alternatives to all input pipes in the local config.
+  validate  Validate local config for proper formatting and internal consistency
   upload    Replace node config with local config. Also tries to upload testdata if 'testdata' folder present.
   download  Replace local config with node config
   dump      Create a zip archive of the config and store it as 'sesam-config.zip'

--- a/sesam.py
+++ b/sesam.py
@@ -973,6 +973,23 @@ class SesamCmdClient:
         else:
             pass
 
+    def validate(self):
+        # check if all the json files are valid
+        # check if .expanded directory exists
+        logger.info("Validating config files")
+        if os.path.exists(self.args.connector_dir + "/.expanded"):
+            for root, dirs, files in os.walk(os.path.join(self.args.connector_dir, ".expanded","pipes")):
+                for file in files:
+                    if file.endswith(".json"):
+                        try:
+                            with open(os.path.join(root, file), "r") as f:
+                                config=json.load(f)
+                        except BaseException as e:
+                            logger.error("Config file '%s' is not valid json" % file)
+
+
+            logger.warning("All json files are valid")
+
     def upload(self):
         # Find env vars to upload
         profile_file = "%s-env.json" % self.args.profile
@@ -2396,7 +2413,7 @@ Commands:
 
     command = args.command and args.command.lower() or ""
 
-    if command not in ["authenticate","upload", "download", "status", "init", "update", "verify", "test", "run", "wipe",
+    if command not in ["authenticate","validate","upload", "download", "status", "init", "update", "verify", "test", "run", "wipe",
                        "restart", "reset", "dump", "stop", "convert"]:
         if command:
             logger.error("Unknown command: '%s'", command)
@@ -2449,6 +2466,8 @@ Commands:
                 (command in allowed_commands_for_non_dev_subscriptions and args.force):
             if command == "authenticate":
                 sesam_cmd_client.authenticate()
+            elif command == "validate":
+                sesam_cmd_client.validate()
             elif command == "upload":
                 if not args.is_connector:
                     sesam_cmd_client.upload()

--- a/sesam.py
+++ b/sesam.py
@@ -975,9 +975,12 @@ class SesamCmdClient:
 
     def validate(self):
         logger.info("Validating config files")
+        # set the current directory when sesam validate is called from root.
+        if self.args.command == "validate" and self.args.connector_dir!=".":
+            os.chdir(self.args.connector_dir)
         is_valid=True
-        if os.path.exists(self.args.connector_dir + "/.expanded"):
-            for root, _, files in os.walk(os.path.join(self.args.connector_dir, ".expanded")):
+        if os.path.exists(".expanded"):
+            for root, _, files in os.walk(".expanded"):
                 if root.endswith("/.expanded"):
                     for file in files:
                         if file.endswith(".json"):
@@ -1045,8 +1048,10 @@ class SesamCmdClient:
                 logger.warning("All config files are valid")
             else:
                 logger.error("One or more config files are not valid. Check the log for more information")
+                sys.exit(1)
         else:
             logger.error("Failed to validate. Config files are not expanded.")
+            sys.exit(1)
 
 
     def upload(self):
@@ -2533,6 +2538,7 @@ Commands:
                 else:
                     os.chdir(args.connector_dir)
                     expand_connector(args.system_placeholder, args.expanded_dir,args.profile)
+                    sesam_cmd_client.validate()
                     os.chdir(args.expanded_dir)
                     sesam_cmd_client.upload()
                     os.chdir(os.pardir) if args.connector_dir == "." else os.chdir(os.path.join(os.pardir, os.pardir))

--- a/sesam.py
+++ b/sesam.py
@@ -974,56 +974,80 @@ class SesamCmdClient:
             pass
 
     def validate(self):
-        # check if all the json files are valid
-        # check if .expanded directory exists
         logger.info("Validating config files")
         is_valid=True
         if os.path.exists(self.args.connector_dir + "/.expanded"):
-            for root, dirs, files in os.walk(os.path.join(self.args.connector_dir, ".expanded","pipes")):
-                for file in files:
-                    if file.endswith(".json"):
-                        try:
-                            with open(os.path.join(root, file), "r") as f:
-                                config=json.load(f)
-                        except BaseException as e:
-                            logger.error("Config file '%s' is not valid json" % file)
-                            is_valid=False
+            for root, _, files in os.walk(os.path.join(self.args.connector_dir, ".expanded")):
+                if root.endswith("/.expanded"):
+                    for file in files:
+                        if file.endswith(".json"):
+                            try:
+                                with open(os.path.join(root, file), "r") as f:
+                                    config=json.load(f)
+                            except BaseException as e:
+                                logger.error("Config file '%s' is not valid json" % file)
+                                is_valid=False
+                elif root.endswith("/systems"):
+                    for file in files:
+                        if file.endswith(".json"):
+                            try:
+                                with open(os.path.join(root, file), "r") as f:
+                                    config=json.load(f)
+                            except BaseException as e:
+                                logger.error("Config file '/systems/%s' is not valid json" % file)
+                                is_valid=False
+                elif root.endswith("/pipes"):
+                    for file in files:
+                        if file.endswith(".json"):
+                            try:
+                                with open(os.path.join(root, file), "r") as f:
+                                    config = json.load(f)
+                            except BaseException as e:
+                                logger.error("Config file '/pipes/%s' is not valid json" % file)
+                                is_valid = False
 
-                        if "collect" in file and type(config.get("transform"))==list:
-                            for transform in config.get("transform"):
-                                if transform.get("template") == "transform-collect-rest":
-                                    if not "exclude_completeness" in config.keys():
-                                        logger.error("Config file '%s' is missing 'exclude_completeness' property" % file)
-                                        is_valid=False
-                                    elif not transform.get("properties"):
-                                        logger.error("Config file '%s' is missing 'properties' property" % file)
-                                        is_valid=False
-                                    elif not transform.get("properties").get("share_dataset"):
-                                        logger.error("Config file '%s' is missing 'share_dataset' property in 'properties'" % file)
-                                        is_valid=False
-                                    elif not transform.get("properties").get("share_dataset") in config.get("exclude_completeness"):
-                                        logger.error("Config file '%s' is missing '%s' in 'exclude_completeness'" % (file, transform.get("properties").get("share_dataset")))
-                                        is_valid=False
-
-                        if "share" in file:
-                            # validate "batch_size": 1 exists on the pipes that has "template": "transform-share-rest"
-                            if type(config.get("transform"))==dict:
-                                if config.get("transform").get("template") == "transform-share-rest":
-                                    if not "batch_size" in config.keys() or config.get("batch_size") != 1:
-                                        logger.error("Config file '%s' is missing 'batch_size' property with value: 1" % file)
-                                        is_valid=False
-                            elif type(config.get("transform"))==list:
+                            if "collect" in file and type(config.get("transform")) == list:
                                 for transform in config.get("transform"):
-                                    if transform.get("template") == "transform-share-rest":
+                                    if transform.get("template") == "transform-collect-rest":
+                                        if not "exclude_completeness" in config.keys():
+                                            logger.error(
+                                                "Config file '/pipes/%s' is missing 'exclude_completeness' property" % file)
+                                            is_valid = False
+                                        elif not transform.get("properties"):
+                                            logger.error("Config file '/pipes/%s' is missing 'properties' property" % file)
+                                            is_valid = False
+                                        elif not transform.get("properties").get("share_dataset"):
+                                            logger.error(
+                                                "Config file '/pipes/%s' is missing 'share_dataset' property in 'properties'" % file)
+                                            is_valid = False
+                                        elif not transform.get("properties").get("share_dataset") in config.get(
+                                                "exclude_completeness"):
+                                            logger.error(
+                                                "Config file '/pipes/%s' is missing '%s' in 'exclude_completeness'" % (
+                                                file, transform.get("properties").get("share_dataset")))
+                                            is_valid = False
+
+                            if "share" in file:
+                                if type(config.get("transform")) == dict:
+                                    if config.get("transform").get("template") == "transform-share-rest":
                                         if not "batch_size" in config.keys() or config.get("batch_size") != 1:
-                                            logger.error("Config file '%s' is missing 'batch_size' property with value: 1" % file)
-                                            is_valid=False
+                                            logger.error(
+                                                "Config file '%s' is missing 'batch_size' property with value: 1" % file)
+                                            is_valid = False
+                                elif type(config.get("transform")) == list:
+                                    for transform in config.get("transform"):
+                                        if transform.get("template") == "transform-share-rest":
+                                            if not "batch_size" in config.keys() or config.get("batch_size") != 1:
+                                                logger.error(
+                                                    "Config file '%s' is missing 'batch_size' property with value: 1" % file)
+                                                is_valid = False
             if is_valid:
                 logger.warning("All config files are valid")
             else:
                 logger.error("One or more config files are not valid. Check the log for more information")
         else:
             logger.error("Failed to validate. Config files are not expanded.")
+
 
     def upload(self):
         # Find env vars to upload
@@ -2507,8 +2531,9 @@ Commands:
                 if not args.is_connector:
                     sesam_cmd_client.upload()
                 else:
-                    expand_connector(args.connector_dir, args.system_placeholder, args.expanded_dir,args.profile)
-                    os.chdir(os.path.join(args.connector_dir, args.expanded_dir))
+                    os.chdir(args.connector_dir)
+                    expand_connector(args.system_placeholder, args.expanded_dir,args.profile)
+                    os.chdir(args.expanded_dir)
                     sesam_cmd_client.upload()
                     os.chdir(os.pardir) if args.connector_dir == "." else os.chdir(os.path.join(os.pardir, os.pardir))
                     sesam_cmd_client.authenticate()


### PR DESCRIPTION
This PR adds "sesam validate" command. It validates the following:
* All configuration is well-formed JSON
* The collect pipe that uses the transform-collect-rest transform has exclude_completeness set for the share dataset it hops to.
* The share pipe that uses the transform-share-rest transform has "batch_size": 1 set (as it hops to the sink dataset).

There is also a bug fix included in the PR: upload and authenticate commands failed when running from the root directory on a connector.