### PR TITLE
IS-14588 Add support for custom template parameters when doing sesampy upload/download

### DIFF
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAG=${SESAM_TAG:-2.5.22}
+TAG=${SESAM_TAG:-2.5.23}
 
 wget -O sesam.tar.gz https://github.com/sesam-community/sesam-py/releases/download/$TAG/sesam-linux-$TAG.tar.gz
 tar -xf sesam.tar.gz

--- a/readme.install.md
+++ b/readme.install.md
@@ -12,7 +12,7 @@ $ virtualenv --python=python3 venv
 $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ python sesam.py -version
-sesam version 2.5.22
+sesam version 2.5.23
 ```
 
 
@@ -24,7 +24,7 @@ $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ pyinstaller --onefile sesam.py
 $ dist/sesam -version
-sesam version 2.5.22
+sesam version 2.5.23
 ```
 
 ### [Back to main page](./README.md)

--- a/readme.usage.md
+++ b/readme.usage.md
@@ -89,6 +89,9 @@ uid=12688f21-c4f5-481d-9b07-dd6a88b738f3
 ...
 ```
 Note that the value must be of the corresponding parameter datatype, though the value itself can be arbitrary.
+It is then used to parse the json with transit encoding when running "upload" command. A reverse lookup takes place
+when running "download" command, and the value is replaced with the corresponding parameter name. So it is recommended to 
+use a near-unique value for each parameter to avoid collisions.
 
 ## Usage
 

--- a/readme.usage.md
+++ b/readme.usage.md
@@ -72,6 +72,24 @@ P.S. Optionally, you can use another filename and location, and then specify it 
 }
 ```
 
+#### 4- jinja_vars
+In order to support custom template parameters in sesampy with json transit encoding, you can add a file named `.jinja_vars`
+in the root directory, paste and edit the following:
+
+```pythonverboseregexp
+custom_param1=custom_value1
+custom_param2=custom_value2
+...
+```
+
+for example:
+```pythonverboseregexp
+connected_ts=2023-03-21T13:17:22Z
+uid=12688f21-c4f5-481d-9b07-dd6a88b738f3
+...
+```
+Note that the value must be of the corresponding parameter datatype, though the value itself can be arbitrary.
+
 ## Usage
 
 ```

--- a/sesam.py
+++ b/sesam.py
@@ -763,25 +763,25 @@ class SesamCmdClient:
 
     def replace_jinja_variables(self, contents):
         jinja_vars=self.read_config_file(".jinja_vars", is_required=False)
-        pattern=r"~t{{@ (?P<variable>[^@}]+) @}}"
-        if "connected_ts" in contents:
-            print(12)
-        modified_contents=re.sub(pattern,r"~t2023-03-21T13:17:22Z",contents)
+        modified_contents=contents
+        for var in jinja_vars:
+            pattern = rf"{{{{@ {var} @}}}}"
+            new_pattern=rf"{jinja_vars[var]}"
+            modified_contents=re.sub(pattern,new_pattern,modified_contents)
         modified_contents = modified_contents.encode("utf-8")
         return modified_contents
 
     def replace_env_variables(self, dir):
-
-        jinja_vars = {v: k for k, v in self.read_config_file(".jinja_vars", is_required=False).items()}
-
+        jinja_vars = self.read_config_file(".jinja_vars", is_required=False)
         for filename in os.listdir(dir):
             if filename.endswith('.json'):
                 with open(os.path.join(dir, filename), 'r+') as file:
                     contents = file.read()
                     modified_contents = contents
                     for var in jinja_vars:
-                        pattern = rf"{var}"
-                        modified_contents = re.sub(pattern, rf"{{@ {jinja_vars[var]} @}}", modified_contents)
+                        pattern=rf"{jinja_vars[var]}"
+                        new_pattern = rf"{{{{@ {var} @}}}}"
+                        modified_contents = re.sub(pattern,new_pattern, modified_contents)
 
                     # modified_contents = re.sub(pattern, r"~t{{@ connected_ts @}}", contents)
                     file.seek(0)

--- a/sesam.py
+++ b/sesam.py
@@ -30,7 +30,7 @@ from connector_cli.connectorpy import *
 from connector_cli.oauth2login import *
 from connector_cli.tripletexlogin import *
 
-sesam_version = "2.5.22"
+sesam_version = "2.5.23"
 
 logger = logging.getLogger('sesam')
 LOGLEVEL_TRACE = 2


### PR DESCRIPTION
This PR adds support for custom template params when using "upload" and "download" commands.

As a user, you have to create a file named .jinja_vars and define a sample value of the same parameter type. The value is then used to parse the JSON with transit encoding when "upload" and a reverse lookup takes place when running the "download" command to substitutes the values with the corresponding parameter name.