### PR TITLE
IS-14663 Fix "sesam status" incorrect output when running on a connector

### DIFF
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAG=${SESAM_TAG:-2.5.22}
+TAG=${SESAM_TAG:-2.5.24}
 
 wget -O sesam.tar.gz https://github.com/sesam-community/sesam-py/releases/download/$TAG/sesam-linux-$TAG.tar.gz
 tar -xf sesam.tar.gz

--- a/readme.install.md
+++ b/readme.install.md
@@ -12,7 +12,7 @@ $ virtualenv --python=python3 venv
 $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ python sesam.py -version
-sesam version 2.5.22
+sesam version 2.5.24
 ```
 
 
@@ -24,7 +24,7 @@ $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ pyinstaller --onefile sesam.py
 $ dist/sesam -version
-sesam version 2.5.22
+sesam version 2.5.24
 ```
 
 ### [Back to main page](./README.md)

--- a/sesam.py
+++ b/sesam.py
@@ -2547,7 +2547,12 @@ Commands:
             elif command == "download":
                 sesam_cmd_client.download()
             elif command == "status":
-                sesam_cmd_client.status()
+                if not args.is_connector:
+                    sesam_cmd_client.status()
+                else:
+                    os.chdir(os.path.join(args.connector_dir, args.expanded_dir))
+                    sesam_cmd_client.status()
+                    os.chdir(os.pardir) if args.connector_dir == "." else os.chdir(os.path.join(os.pardir, os.pardir))
             elif command == "init":
                 sesam_cmd_client.init()
             elif command == "update":

--- a/sesam.py
+++ b/sesam.py
@@ -2550,9 +2550,12 @@ Commands:
                 if not args.is_connector:
                     sesam_cmd_client.status()
                 else:
-                    os.chdir(os.path.join(args.connector_dir, args.expanded_dir))
-                    sesam_cmd_client.status()
-                    os.chdir(os.pardir) if args.connector_dir == "." else os.chdir(os.path.join(os.pardir, os.pardir))
+                    if os.path.exists(os.path.join(args.connector_dir, args.expanded_dir)):
+                        os.chdir(os.path.join(args.connector_dir, args.expanded_dir))
+                        sesam_cmd_client.status()
+                        os.chdir(os.pardir) if args.connector_dir == "." else os.chdir(os.path.join(os.pardir, os.pardir))
+                    else:
+                        logger.error("expanded directory not found. Please upload the configs first or check the input args.")
             elif command == "init":
                 sesam_cmd_client.init()
             elif command == "update":

--- a/sesam.py
+++ b/sesam.py
@@ -30,7 +30,7 @@ from connector_cli.connectorpy import *
 from connector_cli.oauth2login import *
 from connector_cli.tripletexlogin import *
 
-sesam_version = "2.5.22"
+sesam_version = "2.5.24"
 
 logger = logging.getLogger('sesam')
 LOGLEVEL_TRACE = 2


### PR DESCRIPTION
This PR fixes a bug with "sesam status" command when running over a connector.
It is used to compare node config with the local configs inside the root directory, while the actual local config is inside the .expanded directory in case of a connector.