### PR TITLE
IS-14748 Add a way to optionally skip the authenticate part when doing sesam upload

### DIFF
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAG=${SESAM_TAG:-2.5.24}
+TAG=${SESAM_TAG:-2.5.26}
 
 wget -O sesam.tar.gz https://github.com/sesam-community/sesam-py/releases/download/$TAG/sesam-linux-$TAG.tar.gz
 tar -xf sesam.tar.gz

--- a/readme.install.md
+++ b/readme.install.md
@@ -12,7 +12,7 @@ $ virtualenv --python=python3 venv
 $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ python sesam.py -version
-sesam version 2.5.24
+sesam version 2.5.26
 ```
 
 
@@ -24,7 +24,7 @@ $ . venv/bin/activate
 $ pip install -r requirements.txt
 $ pyinstaller --onefile sesam.py
 $ dist/sesam -version
-sesam version 2.5.24
+sesam version 2.5.26
 ```
 
 ### [Back to main page](./README.md)

--- a/readme.usage.md
+++ b/readme.usage.md
@@ -180,6 +180,8 @@ optional arguments:
                         use with the init command to add test entities to input pipes
   -force-add
                         use with the '-add-test-entities' option to overwrite test entities that exist locally
+  -skip-auth            
+                        skip the authentication step after the upload command (available only when working on a connector).
   --system-placeholder <string>
                         Name of the system _id placeholder (available only when working on a connector)
   -d <string>           

--- a/sesam.py
+++ b/sesam.py
@@ -30,7 +30,7 @@ from connector_cli.connectorpy import *
 from connector_cli.oauth2login import *
 from connector_cli.tripletexlogin import *
 
-sesam_version = "2.5.24"
+sesam_version = "2.5.26"
 
 logger = logging.getLogger('sesam')
 LOGLEVEL_TRACE = 2

--- a/sesam.py
+++ b/sesam.py
@@ -2422,6 +2422,9 @@ Commands:
                         help="force the command to run (only for 'upload' and 'download' commands) for non-dev "
                              "subscriptions")
 
+    parser.add_argument('-skip-auth', dest='skip_auth', required=False, action='store_true',
+                        help="skips the authentication step after upload command.")
+
     parser.add_argument("--system-placeholder", metavar="<string>",
                         default="xxxxxx", type=str, help="Name of the system _id placeholder (available only when working on connectors)")
 
@@ -2598,7 +2601,8 @@ Commands:
                     os.chdir(args.expanded_dir)
                     sesam_cmd_client.upload()
                     os.chdir(os.pardir) if args.connector_dir == "." else os.chdir(os.path.join(os.pardir, os.pardir))
-                    sesam_cmd_client.authenticate()
+                    if not args.skip_auth:
+                        sesam_cmd_client.authenticate()
             elif command == "download":
                 sesam_cmd_client.download()
             elif command == "status":


### PR DESCRIPTION
This PR adds a flag to sesampy named -skip-auth to optionally skip the authentication after upload.
Readme is updated accordingly.