### PR TITLE
IS-15126: Only send the client_secret in the authorize request optionally

### DIFF
--- a/connector_cli/oauth2login.py
+++ b/connector_cli/oauth2login.py
@@ -176,6 +176,7 @@ def start_server(args):
     login_url = args.login_url
     token_url = args.token_url
     scopes = args.scopes
+    use_client_secret = args.use_client_secret
     _, manifest = expand_connector_config(system_id)
     if (
         system_id
@@ -188,11 +189,14 @@ def start_server(args):
     ):
         params = {
             "client_id": client_id,
-            "client_secret": client_secret,
             "scope": " ".join(scopes),
             "redirect_uri": redirect_uri,
             "response_type": "code",
         }
+
+        if use_client_secret:
+            params["client_secret"] = client_secret
+            
         if not login_url.endswith("?"):
             login_url += "?"
         sesam_node.logger.info(

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
-TAG=${SESAM_TAG:-2.5.30}
+TAG=${SESAM_TAG:-2.5.31}
 
 wget -O sesam.tar.gz https://github.com/sesam-community/sesam-py/releases/download/$TAG/sesam-linux-$TAG.tar.gz
 tar -xf sesam.tar.gz

--- a/sesam.py
+++ b/sesam.py
@@ -28,7 +28,7 @@ from requests.exceptions import HTTPError
 from connector_cli import connectorpy, oauth2login, tripletexlogin
 from jsonformat import FormatStyle, format_object
 
-sesam_version = "2.5.30"
+sesam_version = "2.5.31"
 
 logger = logging.getLogger("sesam")
 LOGLEVEL_TRACE = 2

--- a/sesam.py
+++ b/sesam.py
@@ -3113,6 +3113,10 @@ Commands:
 
     parser.add_argument("--days", metavar="<string>",
                         type=int, default=10, help="number of days until the token should expire (available only when working on connectors)")
+    
+    parser.add_argument('--use-client-secret', dest='use_client_secret', required=False,
+                        action="store_true",
+                        help="use with sesam upload/authenticate to send add the client_secret parameter to the /authorize URL")
 
     try:
         args = parser.parse_args()


### PR DESCRIPTION
The OAuth2 spec doesn't mention client_secret in the initial /authorize call so let's remove it. In case some system needs it, there's a new --use-client-secret argument you can use that will add it as a parameter to the request, as it was done until now.