### PR TITLE
Use urlsafe b64decode to decode JWT

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ Werkzeug==2.3.7
 PyJWT==1.7.1
 pytest==7.4.3
 jwt~=1.3.1
-pyOpenSSL==21.0.0
-cryptography==3.4.3
+pyOpenSSL==24.1.0
+cryptography==42.0.7
 pycryptodome==3.19.0

--- a/sesam.py
+++ b/sesam.py
@@ -7,7 +7,7 @@ import re
 import sys
 import time
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
-from base64 import b64decode
+from base64 import urlsafe_b64decode
 from configparser import ConfigParser
 from copy import deepcopy
 from decimal import Decimal
@@ -30,7 +30,7 @@ from requests.exceptions import HTTPError, RequestException
 from connector_cli import api_key_login, connectorpy, oauth2login, tripletexlogin
 from jsonformat import FormatStyle, format_object
 
-sesam_version = "2.10.2"
+sesam_version = "2.10.3"
 
 logger = logging.getLogger("sesam")
 LOGLEVEL_TRACE = 2
@@ -202,7 +202,7 @@ class SesamNode:
         # Pull data chunk from the jwt token
         _, payload, _ = self.jwt_token.split(".")
         # Add padding to base64 and decode it
-        jwt_data = json.loads(b64decode(payload + "=="))
+        jwt_data = json.loads(urlsafe_b64decode(payload + "=="))
 
         # Extract the sub ID from the data
         if jwt_data:
@@ -1168,7 +1168,7 @@ class SesamCmdClient:
                     ".authconfig or as arguments."
                 )
                 sys.exit(1)
-            if connector_manifest.get("auth_variant","").lower() == "superoffice-ticket":
+            if connector_manifest.get("auth_variant", "").lower() == "superoffice-ticket":
                 oauth2login.login_via_oauth(self.sesam_node, self.args, require_so_ticket=True)
             else:
                 oauth2login.login_via_oauth(self.sesam_node, self.args)
@@ -3616,11 +3616,12 @@ Commands:
         if not args.is_connector:
             args.jinja_vars = None
             try:
-                if os.path.isfile('.jinja_vars'):
+                if os.path.isfile(".jinja_vars"):
                     args.jinja_vars = sesam_cmd_client.parse_config_file(".jinja_vars")
                     if args.jinja_vars == {}:
-                        logger.warning("No variables found in .jinja_vars file. "
-                                       "Proceeding without it.")
+                        logger.warning(
+                            "No variables found in .jinja_vars file. " "Proceeding without it."
+                        )
                     else:
                         logger.info("Found variables in .jinja_vars file: %s", args.jinja_vars)
             except BaseException:
@@ -3648,7 +3649,11 @@ Commands:
                 node_url, jwt_token, logger, verify_ssl=args.skip_tls_verification is False
             )
         except BaseException as e:
-            if args.verbose or args.extra_verbose:
+            if (
+                args.verbose is True
+                or args.extra_verbose is True
+                or args.extra_extra_verbose is True
+            ):
                 logger.exception(e)
             logger.error(
                 "failed to connect to the sesam node using the url and jwt token "


### PR DESCRIPTION
Had an issue running sesam-py, getting a generic error from the CLI that the node connection information was wrong/invalid.

Turns out the IF case for logging of this issue was problematic (did not print when using -vvv).
After fixing the issue it became clear that the b64 decode function was not behaving as expected. Not sure why. Tried mixing up package versions etc to no avail.

Trying the urlsafe version of b64_decode worked somehow. Not sure why. The `ouath2login.py` file also uses the urlsafe version of the method - so maybe someone here knows the difference that may make?

Anyhow this "works on my machine" and thought I wanted to share.

Original error (after fixing the -vvv logging error):
```
$ python ../../sesam-py/sesam.py test -vvv
Using /Users/gabriellvig/Documents/repos/sesam-node-config/node as base directory
DEBUG:sesamclient.utils:Found config file '.syncconfig' in '/Users/gabriellvig/Documents/repos/sesam-node-config/node'
Cannot locate config file '.sesamconfig.json' in current or parent folder. Proceeding without it.
Invalid base64-encoded string: number of data characters (649) cannot be 1 more than a multiple of 4
Traceback (most recent call last):
  File "/Users/gabriellvig/Documents/repos/sesam-node-config/node/../../sesam-py/sesam.py", line 3647, in <module>
    sesam_cmd_client.sesam_node = SesamNode(
  File "/Users/gabriellvig/Documents/repos/sesam-node-config/node/../../sesam-py/sesam.py", line 205, in __init__
    jwt_data = json.loads(b64decode(payload + "=="))
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/base64.py", line 87, in b64decode
    return binascii.a2b_base64(s)
binascii.Error: Invalid base64-encoded string: number of data characters (649) cannot be 1 more than a multiple of 4
failed to connect to the sesam node using the url and jwt token we were given:
https://datahub-960da600.sesam.cloud/api
eyJ0…
please verify the url and token is correct, and that there isn't any network issues (i.e. firewall, internet connection etc)
```

P.S - The JWT had a length of 650 when checking "len(payload)", but still the function said that it had length 649.