### PR TITLE
IS-18733: Upload error on Mac OS

### DIFF
--- a/sesam.py
+++ b/sesam.py
@@ -1510,7 +1510,9 @@ class SesamCmdClient:
                 self.testdata_queue = queue.Queue()
                 for root, _, files in os.walk("testdata"):
                     for filename in files:
-                        pipe_id = filename.replace(".json", "")
+                        if not filename.lower().endswith(".json"):
+                            continue
+                        pipe_id = os.path.splitext(filename)[0]
                         if self.whitelisted_pipes and pipe_id not in self.whitelisted_pipes:
                             continue
 
@@ -1524,7 +1526,9 @@ class SesamCmdClient:
             else:
                 for root, _, files in os.walk("testdata"):
                     for filename in files:
-                        pipe_id = filename.replace(".json", "")
+                        if not filename.lower().endswith(".json"):
+                            continue
+                        pipe_id = os.path.splitext(filename)[0]
                         if self.whitelisted_pipes and pipe_id not in self.whitelisted_pipes:
                             continue
 
@@ -4012,7 +4016,7 @@ Commands:
                     connectorpy.expand_connector(
                         args.system_placeholder, args.expanded_dir, args.profile
                     )
-                    sesam_cmd_client.validate()
+                    #sesam_cmd_client.validate()
                     os.chdir(args.expanded_dir)
                     sesam_cmd_client.upload()
                     os.chdir(os.pardir) if args.connector_dir == "." else os.chdir(

--- a/sesam.py
+++ b/sesam.py
@@ -32,7 +32,7 @@ from requests.exceptions import RequestException
 from connector_cli import api_key_login, connectorpy, oauth2login, tripletexlogin
 from jsonformat import format_json
 
-sesam_version = "2.11.11"
+sesam_version = "2.11.12"
 
 logger = logging.getLogger("sesam")
 LOGLEVEL_TRACE = 2

--- a/sesam.py
+++ b/sesam.py
@@ -4016,7 +4016,7 @@ Commands:
                     connectorpy.expand_connector(
                         args.system_placeholder, args.expanded_dir, args.profile
                     )
-                    #sesam_cmd_client.validate()
+                    sesam_cmd_client.validate()
                     os.chdir(args.expanded_dir)
                     sesam_cmd_client.upload()
                     os.chdir(os.pardir) if args.connector_dir == "." else os.chdir(


### PR DESCRIPTION
This pull request makes several improvements to the `sesam.py` script, focusing on better file handling for test data uploads and minor maintenance updates. The most significant changes are stricter filtering of test data files to only process `.json` files, a version bump, and a temporary disabling of validation during connector expansion.

**Test data file handling improvements:**

* Updated the logic in the `upload` method to only process files with a `.json` extension (case-insensitive), preventing accidental processing of unrelated files including Mac OS .DS_STORE metadata file. Also, switched from using `replace(".json", "")` to `os.path.splitext(filename)[0]` for more robust filename handling. [[1]](diffhunk://#diff-b00e2cdd790f35273646fa0f925e1d97aa9a384a205a2bfd6fdb3b388e8829f3L1513-R1515) [[2]](diffhunk://#diff-b00e2cdd790f35273646fa0f925e1d97aa9a384a205a2bfd6fdb3b388e8829f3L1527-R1531)

**Maintenance and workflow changes:**

* Bumped the `sesam_version` from `2.11.11` to `2.11.12`.
* Commented out the call to `sesam_cmd_client.validate()` during connector expansion, likely to temporarily skip validation steps.